### PR TITLE
Ondrejruml/be 958 fix crossref fields resolving

### DIFF
--- a/riv/resolvers/crossref.py
+++ b/riv/resolvers/crossref.py
@@ -1,6 +1,21 @@
 import re
 
 from ..resolvers import MetadataResolver
+"""Crossref resolver to retrieve RDM-like metadata based on PID.
+
+Article with announcement of changes to REST API rate limits
+https://doi.org/10.64000/wadve-3tj60
+
+public pool rate limit: 5 requests per second
+
+example: https://api.crossref.org/works/doi/10.64000/wadve-3tj60
+
+polite pool rate limit: 10 requests per second
+available by adding query parameter mailto to API URL
+
+example: https://api.crossref.org/works/doi/10.64000/wadve-3tj60&mailto=info@eosc.cz
+"""
+
 
 HOST_REGEX = re.compile(r'^(?:https?:\/\/)?doi\.org(?:\/.*)?$', re.IGNORECASE)
 DOI_REGEX = re.compile(r'^(?:https?:\/\/)?doi\.org\/(.+)$', re.IGNORECASE)
@@ -68,8 +83,7 @@ class CrossrefResolver(MetadataResolver):
 
     def resolve_title(self, titles):
         for title in titles:
-            if 'title' in title:
-                return title['title']
+            return title
         return ''
 
     def resolve_authors(self, authors):
@@ -77,10 +91,11 @@ class CrossrefResolver(MetadataResolver):
         for crossref_author in authors:
             creator_obj = {
                 "name": crossref_author.get("family", ""),
-                "family": crossref_author.get("family", ""),
+                "family_name": crossref_author.get("family", ""),
+                "type": "personal"
             }
             if crossref_author.get("given"):
-                creator_obj["given"] = crossref_author.get("given", "")
+                creator_obj["given_name"] = crossref_author.get("given", "")
                 creator_obj["name"] += ", " + crossref_author.get("given", "")
             if crossref_author.get("ORCID"):
                 orcid_id = crossref_author.get("ORCID", "").removeprefix("https://orcid.org/")

--- a/riv/tests/test_crossref.py
+++ b/riv/tests/test_crossref.py
@@ -5,7 +5,7 @@ def test_crossref():
     resolver = CrossrefResolver()
 
     data = resolver.resolve("https://doi.org/10.64000/wadve-3tj60")
-    assert data == ({'creators': [{'person_or_org': {'family': 'Rittman', 'given': 'Martyn', 'identifiers': {'identifier': '0000-0001-9327-3734', 'scheme': 'orcid'}, 'name': 'Rittman, Martyn'}}, {'person_or_org': {'family': 'Montilla', 'given': 'Luis', 'identifiers': {'identifier': '0000-0002-7079-6775', 'scheme': 'orcid'}, 'name': 'Montilla, Luis'}}], 'title': ''}, 'OK')
+    assert data == ({'creators': [{'person_or_org': {'family_name': 'Rittman', 'given_name': 'Martyn', 'type': 'personal', 'identifiers': {'identifier': '0000-0001-9327-3734', 'scheme': 'orcid'}, 'name': 'Rittman, Martyn'}}, {'person_or_org': {'family_name': 'Montilla', 'given_name': 'Luis', 'type': 'personal', 'identifiers': {'identifier': '0000-0002-7079-6775', 'scheme': 'orcid'}, 'name': 'Montilla, Luis'}}], 'title': 'Announcing changes to REST API rate limits'}, 'OK')
 
     data = resolver.resolve("10.5281/zenodo.17801829")
     assert data == (None, 'Incorrect URL for crossref identifier.')
@@ -14,7 +14,7 @@ def test_crossref():
     assert data == (None, 'Could not retrieve data, code 404.')
 
     data = resolver.resolve("doi.org/10.64000/wadve-3tj60")
-    assert data == ({'creators': [{'person_or_org': {'family': 'Rittman', 'given': 'Martyn', 'identifiers': {'identifier': '0000-0001-9327-3734', 'scheme': 'orcid'}, 'name': 'Rittman, Martyn'}}, {'person_or_org': {'family': 'Montilla', 'given': 'Luis', 'identifiers': {'identifier': '0000-0002-7079-6775', 'scheme': 'orcid'}, 'name': 'Montilla, Luis'}}], 'title': ''}, 'OK')
+    assert data == ({'creators': [{'person_or_org': {'family_name': 'Rittman', 'given_name': 'Martyn', 'type': 'personal', 'identifiers': {'identifier': '0000-0001-9327-3734', 'scheme': 'orcid'}, 'name': 'Rittman, Martyn'}}, {'person_or_org': {'family_name': 'Montilla', 'given_name': 'Luis', 'type': 'personal', 'identifiers': {'identifier': '0000-0002-7079-6775', 'scheme': 'orcid'}, 'name': 'Montilla, Luis'}}], 'title': 'Announcing changes to REST API rate limits'}, 'OK')
 
     data = resolver.resolve("https://doii.org/10.5281/nonexisting")
     assert data == (None, 'Incorrect URL for crossref identifier.')


### PR DESCRIPTION
Fix structure of returned metadata dictionary in Crossref resolving.
Add polite pooling to crossref resolving (by adding mailto query parameter from config)