### PR TITLE
Mirekys/fix rights

### DIFF
--- a/datasets/model.py
+++ b/datasets/model.py
@@ -114,7 +114,7 @@ class UpdatableRecordServiceMixin:
         # service disables the update on published records completely, regardless
         # of permission policy
         return super(DraftRecordService, self).update(
-            identity, id_, current_data, *args, revision_id=revision_id, **kwargs
+            identity, id_, data, *args, revision_id=revision_id, **kwargs
         )
 
 

--- a/datasets/model.py
+++ b/datasets/model.py
@@ -91,7 +91,7 @@ class UpdatableRecordServiceMixin:
                 continue
 
             if isinstance(title, dict) and title:
-                normalized_rights.append({**right, "title": title})
+                normalized_rights.append(right)
                 continue
 
             if isinstance(title, list) and title and isinstance(title[0], str):

--- a/datasets/model.py
+++ b/datasets/model.py
@@ -72,34 +72,41 @@ class UpdatableRecordServiceMixin:
 
     def update(self, identity, id_, data, *args, revision_id=None, **kwargs):
         """Override update to allow updating published records.
-
-        Note: invenio RDM's editor has an issue that it modifies fields that are
-        not in the editor - for example removes title from rights. To workaround this,
-        we fetch the record here, just propagate the changes from editor fields and
-        leave other fields intact.
         """
-        current_data = self.read(identity, id_).to_dict()
-        if "metadata" not in current_data:
-            current_data["metadata"] = {}
-        metadata = data.get("metadata", {})
-
-        for fld in self.EDITABLE_FIELDS:
-            if fld in metadata:
-                current_data["metadata"][fld] = metadata[fld]
-
+        
         # metadata.rights: invenio rdm can not upload record that has rights that contain both id and title
         # so we remove all other props if there is an id
-        for right in current_data["metadata"].get("rights", []):
-            if "id" in right:
-                for k in list(right.keys()):
-                    if k != "id":
-                        right.pop(k)
+        rights = data["metadata"].get("rights", [])
+        normalized_rights = []
+
+        for right in rights:
+            if "id" in right and isinstance(right["id"], str):
+                normalized_rights.append({"id": right["id"]})
+                continue
+
+            title = right.get("title")
+
+            if isinstance(title, str):
+                normalized_rights.append({"title": {"en": title}})
+                continue
+
+            if isinstance(title, dict) and title:
+                normalized_rights.append({"title": title})
+                continue
+
+            if isinstance(title, list) and title and isinstance(title[0], str):
+                normalized_rights.append({"title": {"en": title[0]}})
+                continue
+
+            # If we get here, the right is invalid → drop it
+        data["metadata"]["rights"] = normalized_rights
+        print(normalized_rights, flush=True)
 
         # metadata/creators/person_or_org/affiliations - can not have identifiers
-        for creator in current_data["metadata"].get("creators", []):
+        for creator in data["metadata"].get("creators", []):
             for aff in creator.get("affiliations", []):
                 aff.pop("identifiers", None)
-        for contributor in current_data["metadata"].get("contributors", []):
+        for contributor in data["metadata"].get("contributors", []):
             for aff in contributor.get("affiliations", []):
                 aff.pop("identifiers", None)
 

--- a/datasets/model.py
+++ b/datasets/model.py
@@ -100,7 +100,6 @@ class UpdatableRecordServiceMixin:
 
             # If we get here, the right is invalid → drop it
         data["metadata"]["rights"] = normalized_rights
-        print(normalized_rights, flush=True)
 
         # metadata/creators/person_or_org/affiliations - can not have identifiers
         for creator in data["metadata"].get("creators", []):

--- a/datasets/model.py
+++ b/datasets/model.py
@@ -87,18 +87,16 @@ class UpdatableRecordServiceMixin:
             title = right.get("title")
 
             if isinstance(title, str):
-                normalized_rights.append({"title": {"en": title}})
+                normalized_rights.append({**right, "title": {"en": title}})
                 continue
 
             if isinstance(title, dict) and title:
-                normalized_rights.append({"title": title})
+                normalized_rights.append({**right, "title": title})
                 continue
 
             if isinstance(title, list) and title and isinstance(title[0], str):
-                normalized_rights.append({"title": {"en": title[0]}})
-                continue
+                normalized_rights.append({**right, "title": {"en": title[0]}})
 
-            # If we get here, the right is invalid → drop it
         data["metadata"]["rights"] = normalized_rights
 
         # metadata/creators/person_or_org/affiliations - can not have identifiers

--- a/uv.lock
+++ b/uv.lock
@@ -167,14 +167,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.12.0"
+version = "4.12.1"
 source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/ce/8a777047513153587e5434fd752e89334ac33e379aa3497db860eeb60377/anyio-4.12.0.tar.gz", hash = "sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0", size = 228266, upload-time = "2025-11-28T23:37:38.911Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl", hash = "sha256:dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb", size = 113362, upload-time = "2025-11-28T23:36:57.897Z" },
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
 ]
 
 [[package]]
@@ -3981,7 +3981,7 @@ wheels = [
 
 [[package]]
 name = "oarepo-model"
-version = "0.1.0.dev43"
+version = "0.1.0.dev44"
 source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple" }
 dependencies = [
     { name = "deepmerge" },
@@ -3991,9 +3991,9 @@ dependencies = [
     { name = "oarepo", extra = ["rdm", "tests"] },
     { name = "oarepo-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/ce/ba439a735a465e6a93a3b4ba61b32c21e4d6bf50ccce3b5ee017a7361cc1/oarepo_model-0.1.0.dev43.tar.gz", hash = "sha256:b260eef5da9fdd027958e56fb8d3121bcb3bb01177046f24e6c71117f1e1cc90", size = 364578, upload-time = "2025-12-31T14:13:03.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/78/5d6ada3673c807c87d46db29f891e6cf79d00fda60d19c6e61e3dc05c9a5/oarepo_model-0.1.0.dev44.tar.gz", hash = "sha256:1c4645492c7c757c606174cd0bd3b31c4c56e55e79f716e4bf9db82fe458233d", size = 365626, upload-time = "2026-01-06T11:06:14.345Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/af/77ef9e33db28e8e60b0ce065e3a79124a56f7fbff3789f52ffcbc6b92cf3/oarepo_model-0.1.0.dev43-py3-none-any.whl", hash = "sha256:43c88753099b24c6358d303cadeec506e5135f0328cf7ed7c5ea14e6b41e9a6d", size = 243531, upload-time = "2025-12-31T14:13:01.432Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/49/463b5e3339fa7323c7c0435e6d775fc2ecac777d79881c810eecc83b41d7/oarepo_model-0.1.0.dev44-py3-none-any.whl", hash = "sha256:8caf63501fd5a958e19a6e96ab61a1976bce66760acf6ee2e3d18a5514c31978", size = 244700, upload-time = "2026-01-06T11:06:12.601Z" },
 ]
 
 [[package]]
@@ -4030,7 +4030,7 @@ wheels = [
 
 [[package]]
 name = "oarepo-rdm"
-version = "1.0.0.dev36"
+version = "1.0.0.dev37"
 source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple" }
 dependencies = [
     { name = "graphlib" },
@@ -4039,9 +4039,9 @@ dependencies = [
     { name = "oarepo-runtime" },
     { name = "oarepo-ui" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/af/7ebb9942d40ecab24f9998a7bf1e8f5a0c3813e572c9fa51310b0ee69a86/oarepo_rdm-1.0.0.dev36.tar.gz", hash = "sha256:73a51734ab68822036e2f11192a99aa7ab6391807d941d1fc078a99b428068a7", size = 39849, upload-time = "2026-01-05T12:37:56.7Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/07/da5f66c0bb86775f0c8c4575734aedf4a5c0fdcf92874e65333ece51ec6e/oarepo_rdm-1.0.0.dev37.tar.gz", hash = "sha256:af631223692c0c9634b134b52124bfcfd7fd41614ec1a0d25fc6a6c2e90d8cd0", size = 39926, upload-time = "2026-01-06T13:35:58.798Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/22/dcec03350e2226b6f3b072a72e938427512919bdd1dc419f302c53ff3d38/oarepo_rdm-1.0.0.dev36-py3-none-any.whl", hash = "sha256:d848942cbe9d005753c3a93157de0fdd2d851e59588d74df18407223021aad1e", size = 77098, upload-time = "2026-01-05T12:37:55.402Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a8/d10cab204a31e5b63c95094a5867d27d2c3c1d8c92230f14a5e0d62c8c4a/oarepo_rdm-1.0.0.dev37-py3-none-any.whl", hash = "sha256:250521f4820d0efb8547643436d1ff6f44337b0c21e985418bc79d6a91432e90", size = 77180, upload-time = "2026-01-06T13:35:57.497Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Properly handles update action with rights without `id` key (e.g. harvested from Catch all). Marshmallow schema then expects multilingual title dictionary only