### PR TITLE
fix copy btn on safari

### DIFF
--- a/assets/less/site/globals/site.overrides
+++ b/assets/less/site/globals/site.overrides
@@ -177,6 +177,9 @@ a.no-text-decoration:hover {
 }
 
 .permanent-link-header {
+  .content {
+    width: 100%;
+  }
   .copy-button {
     color: @white !important;
     margin-left: 0.5rem !important;


### PR DESCRIPTION
Needs https://github.com/oarepo/oarepo-ui/pull/399

It seems that space is calculated slightly differently on safari, so the copy button ends up on the other row after the url. This fixes it.