### PR TITLE
fixed bug with formik errors not reinitializing

### DIFF
--- a/riv/views.py
+++ b/riv/views.py
@@ -15,6 +15,7 @@ from flask_wtf import FlaskForm
 from wtforms import StringField, BooleanField
 from wtforms.validators import DataRequired, URL
 
+
 class StrippedStringField(StringField):
     def process_formdata(self, valuelist):
         if valuelist:
@@ -29,13 +30,13 @@ class RegisterForm(FlaskForm):
         validators=[
             DataRequired(message=_("Please enter a persistent identifier")),
             URL(
-                message=_("Please enter a valid URL (e.g., https://doi.org/... or https://hdl.handle.net/...)")
+                message=_(
+                    "Please enter a valid URL (e.g., https://doi.org/... or https://hdl.handle.net/...)"
+                )
             ),
         ],
-        render_kw={"autofocus": "true", "data-testid": "deposit-create-register-doi-input"},
-    )
-
-    skip_metadata = BooleanField(
-        _("Skip metadata retrieval. Use only in cases when the normal registration process repeatedly fails."),
-        default=False
+        render_kw={
+            "autofocus": "true",
+            "data-testid": "deposit-create-register-doi-input",
+        },
     )

--- a/ui/datasets/semantic-ui/js/datasets/forms/BaseFormLayout.jsx
+++ b/ui/datasets/semantic-ui/js/datasets/forms/BaseFormLayout.jsx
@@ -43,6 +43,7 @@ export const FormTitle = () => {
 const BaseFormLayoutComponent = ({ record, errors = {}, actionState }) => {
   const sidebarRef = React.useRef(null);
   const formFeedbackRef = React.useRef(null);
+  const { setErrors } = useFormikContext();
   const {
     config: { supportContact },
   } = useFormConfig();
@@ -62,6 +63,12 @@ const BaseFormLayoutComponent = ({ record, errors = {}, actionState }) => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
   }, []);
+
+  useEffect(() => {
+    //there is issue with formik not reinitializing properly, because reinitialization happens when record passed to formik
+    // changes, which now sometimes does not happen, as we return 400 and errors and not the record in case of errors
+    setErrors(errors);
+  }, [errors]);
 
   const metadataErrorKeys = Object.keys(errors.metadata || {});
 

--- a/ui/datasets/semantic-ui/js/datasets/forms/FormFieldsContainer.jsx
+++ b/ui/datasets/semantic-ui/js/datasets/forms/FormFieldsContainer.jsx
@@ -8,12 +8,8 @@ import {
 } from "@js/oarepo_ui/forms";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
-import { ResourceTypeField } from "@js/invenio_rdm_records";
 
 const FormFieldsContainerComponent = ({ record }) => {
-  const {
-    config: { vocabularies },
-  } = useFormConfig();
   return (
     <React.Fragment>
       <TextField fieldPath="metadata.title" />

--- a/ui/datasets/templates/semantic-ui/datasets/Deposit.jinja
+++ b/ui/datasets/templates/semantic-ui/datasets/Deposit.jinja
@@ -40,12 +40,6 @@
                     <p class="text-tiny text-muted block rel-mt-2">
                         {% trans %}By submitting this Persistent Identifier (PID) using the <strong>Obtain the link for RIV submission</strong> button, you declare that you have the legal right or authorization to register, curate, or otherwise manage the associated dataset within the National Metadata Directory (NMD). You confirm that the registration of this dataset does not infringe any intellectual property rights, contractual obligations, confidentiality agreements, or applicable institutional or funding rules.{% endtrans %}
                     </p>
-                    <div class="field rel-mt-2">
-                        <div class="ui checkbox">
-                            {{ form.skip_metadata }}
-                            <label for="{{ form.skip_metadata.id }}">{{ form.skip_metadata.label.text }}</label>
-                        </div>
-                    </div>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
There are a few issues with using draft principle i.e. depending on which call gets executed, the "self" link used for the api call also changes between one ending with /draft and not, which causes strange behavior. It is safer to fix this on the front end, while keeping BE as before. 