### PR TITLE
feat: add k6 breaking-point tests & /metrics

### DIFF
--- a/common/wsgi.py
+++ b/common/wsgi.py
@@ -17,6 +17,5 @@ application = create_app()
 
 REST API is mounted under ``/api``.
 """
-# TODO: just a quick POC - find a better place for this module
 metrics = UWsgiPrometheusMetrics(application)
 metrics.start_http_server(int(os.getenv("METRICS_PORT")))

--- a/common/wsgi.py
+++ b/common/wsgi.py
@@ -18,4 +18,4 @@ application = create_app()
 REST API is mounted under ``/api``.
 """
 metrics = UWsgiPrometheusMetrics(application)
-metrics.start_http_server(int(os.getenv("METRICS_PORT")))
+metrics.start_http_server(int(os.getenv("INVENIO_METRICS_PORT")))

--- a/datasets/wsgi.py
+++ b/datasets/wsgi.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""UI + REST WSGI application for Invenio flavours with /metrics."""
+import os
+
+from invenio_app.factory import create_app
+from prometheus_flask_exporter.multiprocess import UWsgiPrometheusMetrics
+
+application = create_app()
+"""Combined UI + REST Flask application.
+
+REST API is mounted under ``/api``.
+"""
+# TODO: just a quick POC - find a better place for this module
+metrics = UWsgiPrometheusMetrics(application)
+metrics.start_http_server(int(os.getenv("METRICS_PORT")))

--- a/k6/package.json
+++ b/k6/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "k6",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.12.1",
+  "devDependencies": {
+    "@types/k6": "^1.5.0"
+  }
+}

--- a/k6/scripts/breaking-point.js
+++ b/k6/scripts/breaking-point.js
@@ -6,7 +6,7 @@ import { Trend, Rate } from 'k6/metrics';
 const BASE_URL = __ENV.BASE_URL || 'https://127.0.0.1:5000';
 const MAX_VUS = __ENV.MAX_VUS || 1000
 const MAX_RPS = __ENV.MAX_RPS || MAX_VUS
-const DURATION = __ENV.BASE_URL || '30m'
+const DURATION = __ENV.DURATION || '30m'
 const SEARCH_URL = `${BASE_URL}/api/datasets`
 const SEARCH_UI_URL = `${BASE_URL}/datasets`
 const ABORT_ON_UX_FAIL = false;

--- a/k6/scripts/breaking-point.js
+++ b/k6/scripts/breaking-point.js
@@ -15,6 +15,7 @@ const ABORT_ON_UX_FAIL = false;
 const searchLatency = new Trend('search_latency');
 const recordLatency = new Trend('record_latency');
 const idLookupLatency = new Trend('id_lookup_latency');
+const pingLatency = new Trend('ping_latency');
 const errorRate = new Rate('errors');
 
 // k6 options — progressive ramping to find breakpoint
@@ -34,17 +35,21 @@ export const options = {
         // Overall KPIs tied to UX
         errors: [{ threshold: 'rate<0.01', abortOnFail: true, delayAbortEval: '10s' }],
         http_req_failed: [{
-            threshold: 'rate<0.01', abortOnFail: true, delayAbortEval: '10s', // string
-        }],      // <1% HTTP errors tolerated
+            threshold: 'rate<0.02', abortOnFail: true, delayAbortEval: '10s',
+        }],      // <2% HTTP errors tolerated
         http_req_duration: [{
-            threshold: 'p(95)<3000', abortOnFail: ABORT_ON_UX_FAIL, delayAbortEval: '10s', // string
-        }],   // 95% < 3s for generic http requests
+            threshold: 'p(75)<5000', abortOnFail: ABORT_ON_UX_FAIL, delayAbortEval: '10s',
+        }],   // 95% < 5s for generic http requests
         search_latency: [{
-            threshold: 'p(95)<3000', abortOnFail: ABORT_ON_UX_FAIL, delayAbortEval: '10s', // string
+            threshold: 'p(95)<3000', abortOnFail: ABORT_ON_UX_FAIL, delayAbortEval: '10s',
         }],      // 95% < ~3s for search
         record_latency: [{
-            threshold: 'p(95)<1500', abortOnFail: ABORT_ON_UX_FAIL, delayAbortEval: '10s', // string
+            threshold: 'p(95)<1500', abortOnFail: ABORT_ON_UX_FAIL, delayAbortEval: '10s',
         }],      // 95% < ~1.5s for detail
+        ping_latency: [{
+            threshold: 'p(99)<5000', abortOnFail: true, delayAbortEval: '10s',
+        }],      // 95% < ~5s for ping - same as liveliness probe timeout
+
     },
     insecureSkipTLSVerify: BASE_URL === 'https://127.0.0.1:5000',
 };
@@ -52,7 +57,29 @@ export const options = {
 // Default sleep time between requests
 const THINK_TIME = 1 + Math.random() * 2;
 
+function isJsonResponse (res) {
+    const ct = res.headers['Content-Type'] || res.headers['content-type'];
+    return ct && ct.includes('application/json');
+}
+
+function safeJson (res) {
+    try {
+        return res.json();
+    } catch (e) {
+        console.error(res)
+        return null;
+    }
+}
+
 export default function () {
+
+    const pingRes = http.get(`${BASE_URL}/ping`);
+    pingLatency.add(pingRes.timings.duration);
+    const ok = check(pingRes, {
+        'liveliness HTTP 200': (r) => r.status === 200,
+    });
+    if (!ok) errorRate.add(1);
+
     group('Landing page', () => {
         // 1) Homepage load
         const res = http.get(`${BASE_URL}/`);
@@ -72,7 +99,16 @@ export default function () {
 
         const ok = check(res, {
             'search HTTP 200': (r) => r.status === 200,
-            'search contains hits': (r) => (r.json().hits && r.json().hits.hits?.length !== undefined),
+            'search contains hits': (r) => {
+                if (!isJsonResponse(r)) return false;
+
+                const body = safeJson(r);
+                return (
+                    body &&
+                    body.hits &&
+                    Array.isArray(body.hits.hits)
+                );
+            }
         });
         if (!ok) errorRate.add(1);
     });

--- a/k6/scripts/breaking-point.js
+++ b/k6/scripts/breaking-point.js
@@ -5,6 +5,7 @@ import { Trend, Rate } from 'k6/metrics';
 // Base configuration
 const BASE_URL = __ENV.BASE_URL || 'https://127.0.0.1:5000';
 const MAX_VUS = __ENV.MAX_VUS || 1000
+const MAX_RPS = __ENV.MAX_RPS || MAX_VUS
 const DURATION = __ENV.BASE_URL || '30m'
 const SEARCH_URL = `${BASE_URL}/api/datasets`
 const SEARCH_UI_URL = `${BASE_URL}/datasets`
@@ -22,9 +23,8 @@ export const options = {
         breakpoint: {
             executor: 'ramping-arrival-rate', //Assure load increase if the system slows
             preAllocatedVUs: 1,
-            maxVUs: MAX_VUS,
             stages: [
-                { target: MAX_VUS, duration: DURATION },
+                { target: MAX_RPS, duration: DURATION },
             ],
         }
     },

--- a/k6/scripts/breaking-point.js
+++ b/k6/scripts/breaking-point.js
@@ -1,0 +1,163 @@
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+
+// Base configuration
+const BASE_URL = __ENV.BASE_URL || 'https://127.0.0.1:5000';
+const MAX_VUS = __ENV.MAX_VUS || 1000
+const DURATION = __ENV.BASE_URL || '30m'
+const SEARCH_URL = `${BASE_URL}/api/datasets`
+const SEARCH_UI_URL = `${BASE_URL}/datasets`
+const ABORT_ON_UX_FAIL = false;
+
+// Metrics
+const searchLatency = new Trend('search_latency');
+const recordLatency = new Trend('record_latency');
+const idLookupLatency = new Trend('id_lookup_latency');
+const errorRate = new Rate('errors');
+
+// k6 options — progressive ramping to find breakpoint
+export const options = {
+    scenarios: {
+        breakpoint: {
+            executor: 'ramping-arrival-rate', //Assure load increase if the system slows
+            preAllocatedVUs: 1,
+            maxVUs: MAX_VUS,
+            stages: [
+                { target: MAX_VUS, duration: DURATION },
+            ],
+        }
+    },
+
+    thresholds: {
+        // Overall KPIs tied to UX
+        errors: [{ threshold: 'rate<0.01', abortOnFail: true, delayAbortEval: '10s' }],
+        http_req_failed: [{
+            threshold: 'rate<0.01', abortOnFail: true, delayAbortEval: '10s', // string
+        }],      // <1% HTTP errors tolerated
+        http_req_duration: [{
+            threshold: 'p(95)<3000', abortOnFail: ABORT_ON_UX_FAIL, delayAbortEval: '10s', // string
+        }],   // 95% < 3s for generic http requests
+        search_latency: [{
+            threshold: 'p(95)<3000', abortOnFail: ABORT_ON_UX_FAIL, delayAbortEval: '10s', // string
+        }],      // 95% < ~3s for search
+        record_latency: [{
+            threshold: 'p(95)<1500', abortOnFail: ABORT_ON_UX_FAIL, delayAbortEval: '10s', // string
+        }],      // 95% < ~1.5s for detail
+    },
+    insecureSkipTLSVerify: BASE_URL === 'https://127.0.0.1:5000',
+};
+
+// Default sleep time between requests
+const THINK_TIME = 1 + Math.random() * 2;
+
+export default function () {
+    group('Landing page', () => {
+        // 1) Homepage load
+        const res = http.get(`${BASE_URL}/`);
+        const ok = check(res, {
+            'landing page HTTP 200': (r) => r.status === 200,
+        });
+        if (!ok) errorRate.add(1);
+    });
+
+    sleep(THINK_TIME);
+
+    group('Browse all records', () => {
+        // 2) Search — base empty query (UI typically uses empty q to load all)
+        const url = `${SEARCH_URL}?q=&page=1&size=10`;
+        const res = http.get(url, { headers: { Accept: 'application/json' } });
+        searchLatency.add(res.timings.duration);
+
+        const ok = check(res, {
+            'search HTTP 200': (r) => r.status === 200,
+            'search contains hits': (r) => (r.json().hits && r.json().hits.hits?.length !== undefined),
+        });
+        if (!ok) errorRate.add(1);
+    });
+
+    sleep(THINK_TIME);
+
+    group('Search a term', () => {
+        // 3) Search — keyword query
+        const url = `${SEARCH_URL}?q=open&page=1&size=10`;
+        const res = http.get(url, { headers: { Accept: 'application/json' } });
+        searchLatency.add(res.timings.duration);
+
+        const ok = check(res, {
+            'keyword search HTTP 200': (r) => r.status === 200,
+        });
+        if (!ok) errorRate.add(1);
+    });
+
+    sleep(THINK_TIME);
+
+    group('Faceted search', () => {
+        // 4) Facet filtering - filter results by resource type & language
+        const url = `${SEARCH_URL}?f=metadata.resource_type:dataset&f=metadata.languages:ces&page=1&size=10`;
+        const res = http.get(url, { headers: { Accept: 'application/json' } });
+        searchLatency.add(res.timings.duration);
+
+        const ok = check(res, {
+            'facet search HTTP 200': (r) => r.status === 200,
+        });
+        if (!ok) errorRate.add(1);
+    });
+
+    sleep(THINK_TIME);
+
+    group('Dataset detail page', () => {
+        // 5) Record detail — pick 1 from search results & export as DataCite JSON
+        const listRes = http.get(`${SEARCH_URL}?page=1&size=1`, { headers: { Accept: 'application/json' } });
+        if (listRes.status === 200) {
+            const hits = listRes.json().hits.hits;
+            if (hits && hits.length > 0) {
+                const record_link = hits[0].links.self_html;
+                const detailRes = http.get(record_link, { headers: { Accept: 'text/html' } });
+                recordLatency.add(detailRes.timings.duration);
+
+                const ok = check(detailRes, {
+                    'record detail HTTP 200': (r) => r.status === 200,
+                });
+                if (!ok) errorRate.add(1);
+            }
+        } else {
+            errorRate.add(1);
+        }
+    });
+
+    sleep(THINK_TIME);
+
+    group('Look up by identifier', () => {
+        const identifierPool = [
+            'https://doi.org/10.5281/zenodo.17162434',
+            'https://doi.org/10.5281/zenodo.8033351',
+            'https://doi.org/10.5281/zenodo.16753981',
+            'https://hdl.handle.net/20.500.14391/3611'
+        ]
+
+        const identifier = identifierPool[Math.floor(Math.random() * identifierPool.length)];
+
+        const searchRes = http.get(`${SEARCH_UI_URL}?q=${encodeURIComponent(identifier)}`, { redirects: 0 });
+
+        idLookupLatency.add(searchRes.timings.duration);
+
+        if (searchRes.status === 302 && searchRes.headers["Location"]) {
+            const detailUrl = searchRes.headers["Location"];
+            const detailRes = http.get(`${BASE_URL}${detailUrl}`, { headers: { Accept: 'text/html' } });
+
+            recordLatency.add(detailRes.timings.duration);
+
+            const ok = check(detailRes, {
+                'record detail HTTP 200': (r) => r.status === 200,
+                'record detail contains identifier': (r) => r.body.includes(identifier)
+            });
+
+            if (!ok) errorRate.add(1);
+        } else {
+            errorRate.add(1);
+        }
+    });
+
+    sleep(THINK_TIME);
+}

--- a/k6/scripts/breaking-point.js
+++ b/k6/scripts/breaking-point.js
@@ -33,7 +33,7 @@ export const options = {
 
     thresholds: {
         // Overall KPIs tied to UX
-        errors: [{ threshold: 'rate<0.01', abortOnFail: true, delayAbortEval: '10s' }],
+        errors: [{ threshold: 'rate<0.01', abortOnFail: false, delayAbortEval: '10s' }],
         http_req_failed: [{
             threshold: 'rate<0.02', abortOnFail: true, delayAbortEval: '10s',
         }],      // <2% HTTP errors tolerated

--- a/k6/scripts/breaking-point.js
+++ b/k6/scripts/breaking-point.js
@@ -23,6 +23,7 @@ export const options = {
         breakpoint: {
             executor: 'ramping-arrival-rate', //Assure load increase if the system slows
             preAllocatedVUs: 1,
+            maxVUs: MAX_VUS,
             stages: [
                 { target: MAX_RPS, duration: DURATION },
             ],

--- a/metrics/__init__.py
+++ b/metrics/__init__.py
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of nma (see https://github.com/EOSC-CZ/nma).
+#
+# oarepo-runtime is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+
+"""Metrics exporter module."""

--- a/metrics/ext.py
+++ b/metrics/ext.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of nma (see https://github.com/EOSC-CZ/nma).
+#
+# oarepo-runtime is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Prometheus Metrics exporter extension."""
+
+
+from flask import Flask
+from prometheus_flask_exporter import PrometheusMetrics
+
+
+class PrometheusMetricsExporterExt:
+    def __init__(self, app: Flask | None = None):
+        """Extension initialization."""
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app: Flask) -> None:
+        """Flask application initialization."""
+        self.app = app
+        metrics = PrometheusMetrics.for_app_factory()
+        metrics.init_app(app)
+
+        app.extensions["metrics-extension"] = self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     "rapidfuzz",
     "oarepo-vocabularies>=3.0.0dev6,<4.0.0",
     "oarepo-oai-pmh-harvester>=6.0.0.dev2,<7.0.0",
-    "traceback-with-variables", # for better error logging
+    "traceback-with-variables",                    # for better error logging
+    "prometheus-flask-exporter",                   # to expose Flask app /metrics to prometheus
 ]
 requires-python = ">=3.13,<3.15"
 
@@ -82,16 +83,8 @@ manage_record_action = "datasets.permissions:manage_record_action"
 
 [tool.uv.build-backend]
 module-root = ""
-module-name = [
-    "common",
-    "i18n",
-    "ui",
-    "datasets",
-]
+module-name = ["common", "i18n", "ui", "datasets"]
 
 [build-system]
-requires = [
-    "uv_build>=0.8.7,<0.9.0",
-]
+requires = ["uv_build>=0.8.7,<0.9.0"]
 build-backend = "uv_build"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ riv_extension = "riv.ext:RIVResolverExtension"
 
 [project.entry-points."invenio_base.apps"]
 riv_extension = "riv.ext:RIVResolverExtension"
+metrics_extension = "metrics.ext:PrometheusMetricsExporterExt"
 
 [project.entry-points."invenio_assets.webpack"]
 i18n = "i18n.webpack:theme"

--- a/riv/ext.py
+++ b/riv/ext.py
@@ -17,7 +17,6 @@ from invenio_base.utils import obj_or_import_string
 from flask import Flask
 from .resolvers.base import MetadataResolver
 from .resolvers.registry import ResolverRegistry
-from prometheus_flask_exporter import PrometheusMetrics
 
 if TYPE_CHECKING:  # pragma: no cover
     from flask import Flask
@@ -33,9 +32,6 @@ class RIVResolverExtension:
         """Flask application initialization."""
         self.app = app
         self.init_config(app)
-        # TODO: just a quick POC - find a better ext module for this
-        metrics = PrometheusMetrics.for_app_factory()
-        metrics.init_app(app)
 
         self.resolver_registry = ResolverRegistry()
 

--- a/riv/ext.py
+++ b/riv/ext.py
@@ -17,8 +17,11 @@ from invenio_base.utils import obj_or_import_string
 from flask import Flask
 from .resolvers.base import MetadataResolver
 from .resolvers.registry import ResolverRegistry
+from prometheus_flask_exporter import PrometheusMetrics
+
 if TYPE_CHECKING:  # pragma: no cover
     from flask import Flask
+
 
 class RIVResolverExtension:
     def __init__(self, app: Flask | None = None):
@@ -30,20 +33,30 @@ class RIVResolverExtension:
         """Flask application initialization."""
         self.app = app
         self.init_config(app)
-        self.resolver_registry =ResolverRegistry()
+        # TODO: just a quick POC - find a better ext module for this
+        metrics = PrometheusMetrics.for_app_factory()
+        metrics.init_app(app)
+
+        self.resolver_registry = ResolverRegistry()
 
         app.extensions["riv-extension"] = self
 
     def init_config(self, app: Flask) -> None:
         """Initialize the configuration for the extension."""
-        app.config.setdefault("PERSISTENT_IDENTIFIER_RESOLVERS", config.PERSISTENT_IDENTIFIER_RESOLVERS)
-        app.config.setdefault("PERSISTENT_IDENTIFIER_PATTERNS", config.PERSISTENT_IDENTIFIER_PATTERNS)
+        app.config.setdefault(
+            "PERSISTENT_IDENTIFIER_RESOLVERS", config.PERSISTENT_IDENTIFIER_RESOLVERS
+        )
+        app.config.setdefault(
+            "PERSISTENT_IDENTIFIER_PATTERNS", config.PERSISTENT_IDENTIFIER_PATTERNS
+        )
         app.config.setdefault("DATACITE_URL", config.DATACITE_URL)
         app.config.setdefault("HANDLE_URL", config.HANDLE_URL)
         app.config.setdefault("CROSSREF_URL", config.CROSSREF_URL)
 
     @cached_property
-    def persistent_identifiers_resolvers(self)-> List[MetadataResolver]:
+    def persistent_identifiers_resolvers(self) -> List[MetadataResolver]:
         """Return resolvers for persistent identifiers."""
-        return [obj_or_import_string(res)() for res in self.app.config["PERSISTENT_IDENTIFIER_RESOLVERS"]]
-
+        return [
+            obj_or_import_string(res)()
+            for res in self.app.config["PERSISTENT_IDENTIFIER_RESOLVERS"]
+        ]

--- a/uv.lock
+++ b/uv.lock
@@ -3559,6 +3559,7 @@ dependencies = [
     { name = "oarepo-theme" },
     { name = "oarepo-ui" },
     { name = "oarepo-vocabularies" },
+    { name = "prometheus-flask-exporter" },
     { name = "python-dotenv" },
     { name = "rapidfuzz" },
     { name = "traceback-with-variables" },
@@ -3580,6 +3581,7 @@ requires-dist = [
     { name = "oarepo-theme", specifier = ">=1.0.0.dev3,<2.0.0" },
     { name = "oarepo-ui", specifier = ">=6.0.0.dev0,<7.0.0" },
     { name = "oarepo-vocabularies", specifier = ">=3.0.0.dev6,<4.0.0" },
+    { name = "prometheus-flask-exporter" },
     { name = "python-dotenv" },
     { name = "rapidfuzz" },
     { name = "traceback-with-variables" },
@@ -3957,14 +3959,14 @@ wheels = [
 
 [[package]]
 name = "oarepo-glitchtip"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple" }
 dependencies = [
     { name = "sentry-sdk", extra = ["flask"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/00/1314d093dd60fd80c8f43cdcbb027c9b59839b5d5a45494b2c94b886ba90/oarepo_glitchtip-1.1.0.tar.gz", hash = "sha256:e9d3029fd6421dd3667b07b82b2f9c99e5ff6e91c828cb30ebe713a28c32dc02", size = 3965, upload-time = "2025-12-09T07:49:10.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/90/787bde2bf25ca5858c02c005ca02fd9afdb81e24bf7c82bb5b397f7240f0/oarepo_glitchtip-1.1.1.tar.gz", hash = "sha256:e0bbc52368c6f470e799287142cd224b60818d872b940f80a1b305e84d23e88c", size = 4003, upload-time = "2026-01-13T09:44:06.216Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/59/6a9c4aac1035b81c1609b0ce717bbfe216bbea622d2460065e2dbc78277a/oarepo_glitchtip-1.1.0-py3-none-any.whl", hash = "sha256:1fcd4223f06f2dcb6b184be940c62c684f2c10b01df2d64318ad8f1dd90e5056", size = 5045, upload-time = "2025-12-09T07:49:09.143Z" },
+    { url = "https://files.pythonhosted.org/packages/77/2e/4408908927b24cbcb8b16dcbbf7619041dca19507eadf6682306b830da45/oarepo_glitchtip-1.1.1-py3-none-any.whl", hash = "sha256:d80def7596ebc64c27d874025f57a1f27c339acee44647a35f2d4cc8edf117cd", size = 5083, upload-time = "2026-01-13T09:44:05.103Z" },
 ]
 
 [[package]]
@@ -4046,7 +4048,7 @@ wheels = [
 
 [[package]]
 name = "oarepo-runtime"
-version = "2.0.0.dev53"
+version = "2.0.0.dev54"
 source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple" }
 dependencies = [
     { name = "langcodes" },
@@ -4054,9 +4056,9 @@ dependencies = [
     { name = "oarepo-invenio-typing-stubs" },
     { name = "signposting" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/51/86f5adc217c383e3c80c1f37188e6b429cda201b389e65b889ce0d335524/oarepo_runtime-2.0.0.dev53.tar.gz", hash = "sha256:c56dcb4920c9507ce9f9963c933236b6d98f7dba492f0c2dba7fcbcdac9ae346", size = 46542, upload-time = "2026-01-07T13:03:16.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/ab/154f7ec771096b205b5852d6a2742b06039caff074e38c02fa8dfc799be6/oarepo_runtime-2.0.0.dev54.tar.gz", hash = "sha256:49ee92270728537370aefbf9e56c7bc644fffe130908477e94c9de4e176ac51d", size = 47172, upload-time = "2026-01-13T13:12:32.38Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/98/7fa2117ed17c68a8a127be33f8e34bd70f935329421fef94e6427ce47c98/oarepo_runtime-2.0.0.dev53-py3-none-any.whl", hash = "sha256:1da5e81b460425a1675d704d16c471c819dad2e1f765d9fbae5a101d7f5a0d2c", size = 70644, upload-time = "2026-01-07T13:03:15.34Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b6/6f17b5d104d55c071c7438879da09ab5f7f46d3802f705c65ee5be7bf904/oarepo_runtime-2.0.0.dev54-py3-none-any.whl", hash = "sha256:83a97393956b675d5e191ff4faecae669e5a61a899ce5c4a3d707751a04bd901", size = 71305, upload-time = "2026-01-13T13:12:31.006Z" },
 ]
 
 [[package]]
@@ -4073,7 +4075,7 @@ wheels = [
 
 [[package]]
 name = "oarepo-ui"
-version = "6.0.0.dev28"
+version = "6.0.0.dev29"
 source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple" }
 dependencies = [
     { name = "deepmerge" },
@@ -4085,9 +4087,9 @@ dependencies = [
     { name = "oarepo-theme" },
     { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/b4/208e96e119f3d0030dc9a960b1dec1b7ebe79a09b3d5ca362452585ae508/oarepo_ui-6.0.0.dev28.tar.gz", hash = "sha256:e7ee4d8bd79b6634981d00e68f12703c32b7628537efdf9357687cac40d399a6", size = 193746, upload-time = "2026-01-08T15:34:30.251Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e5/3a15a7621eb36b0b0acfa623c135b6a6861ee1a898b4f4982bd509013ef8/oarepo_ui-6.0.0.dev29.tar.gz", hash = "sha256:60000047979d04916974d6dea39a561a6e7b0655e9ca4b800721e91cdad5fcd9", size = 193882, upload-time = "2026-01-12T12:24:13.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/56/19afa4cbe55ec2459c44acc659bb59575b81604fa180125c5b9a69b48fb5/oarepo_ui-6.0.0.dev28-py3-none-any.whl", hash = "sha256:aca890d159080b47f0c885da236c0eb42a66572734c9333edce179580838ce31", size = 321867, upload-time = "2026-01-08T15:34:28.912Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c0/f0412f719463b6ddf825fdfc0356d5d1ef7473c9be72e344634ac83a8a1f/oarepo_ui-6.0.0.dev29-py3-none-any.whl", hash = "sha256:de48075c5fee2b556622c59789328267491e93644a0cb8cc0345596e1f502505", size = 321937, upload-time = "2026-01-12T12:24:11.411Z" },
 ]
 
 [[package]]
@@ -4495,6 +4497,28 @@ source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/py
 sdist = { url = "https://files.pythonhosted.org/packages/10/9a/79b1067d27e38ddf84fe7da6ec516f1743f31f752c6122193e7bce38bdbf/polib-1.2.0.tar.gz", hash = "sha256:f3ef94aefed6e183e342a8a269ae1fc4742ba193186ad76f175938621dbfc26b", size = 161658, upload-time = "2023-02-23T17:53:56.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/99/45bb1f9926efe370c6dbe324741c749658e44cb060124f28dad201202274/polib-1.2.0-py2.py3-none-any.whl", hash = "sha256:1c77ee1b81feb31df9bca258cbc58db1bbb32d10214b173882452c73af06d62d", size = 20634, upload-time = "2023-02-23T17:53:59.919Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
+]
+
+[[package]]
+name = "prometheus-flask-exporter"
+version = "0.23.2"
+source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/40/736bd2cb19b065cea395deb57b5b520a2df105dab92af3fb200ee560ad92/prometheus_flask_exporter-0.23.2.tar.gz", hash = "sha256:41fc9bbd7d48cc958ed8384aacf60c3621d9e903768be61c4e7f0c63872eaf1a", size = 31801, upload-time = "2025-03-11T23:05:30.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/04/486040e241708a723ee7673d98733c35f2cf081f63ced0091124b8572177/prometheus_flask_exporter-0.23.2-py3-none-any.whl", hash = "sha256:94922a636d4c1d8b68e1ee605c30a23e9bbb0b21756df8222aa919634871784c", size = 19002, upload-time = "2025-03-11T23:05:29.176Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Tests the repository instance by gradually ramping up VUs & requests/s, until service failure happens and test aborts (either errors starts appearing or UX KPIs tresholds are hit - when `ABORT_ON_UX_FAIL` set to true)

Usage:
```
BASE_URL=https://nma.eosc.cz MAX_VUS=1000 DURATION=30m k6 run ./scripts/breaking-point.js`
```

Also exposes Flask/uwsgi app `/metrics` based on this example: https://github.com/rycus86/prometheus_flask_exporter/tree/master/examples/uwsgi

# Deployment changes

## New ENV variables for WEB container
```Dockerfile
# Temp directory for metrics server
ENV PROMETHEUS_MULTIPROC_DIR /tmp
ENV prometheus_multiproc_dir /tmp
# Port that additional uwsgi metrics server listens on
ENV INVENIO_METRICS_PORT 9200
```

## Prometheus scraping

Following POD template annotations should be added to WEB deployment:
```
prometheus.io/path: /metrics
prometheus.io/port: 9200
prometheus.io/scrape: true
```

## UWSGI.ini module

Change application module in `uwsgi.ini` to:
```
module = common.wsgi:application
```

## Docs
https://github.com/rycus86/prometheus_flask_exporter
