### PR TITLE
fix: ux fixes to make permalink easily selectable

### DIFF
--- a/assets/less/site/globals/site.overrides
+++ b/assets/less/site/globals/site.overrides
@@ -179,6 +179,8 @@ a.no-text-decoration:hover {
 .permanent-link-header {
   .content {
     width: 100%;
+    background-color: darken(@primaryColor, 5%);
+    border-radius: @borderRadius;
   }
   .copy-button {
     color: @white !important;
@@ -191,7 +193,7 @@ a.no-text-decoration:hover {
     background-color: darken(@green, 5%) !important;
   }
 
-  a.permanent-link {
+  span.permanent-link {
     color: @white;
   }
 

--- a/ui/datasets/templates/semantic-ui/datasets/record_detail/permalink.html
+++ b/ui/datasets/templates/semantic-ui/datasets/record_detail/permalink.html
@@ -1,13 +1,8 @@
 {% set record_permalink = record_ui.links.self_persistent_html or record_ui.links.self_html %}
 
 <h3 class="ui inverted header permanent-link-header">
-    <div class="content">
-        <i class="ui icon linkify"></i>
-        <a class="permanent-link" href="{{record_permalink}}" target="_blank" rel="noopener noreferrer"
-        data-testid="record-detail-title-permanent-link">
-            <span class="middle-ellipsis">{{ record_permalink }}</span>
-        </a>
-        <ClipboardCopyButton className="large" copyText={{record_permalink}} />
+    <div class="content rel-p-1">
+        <i class="ui icon linkify mr-10"></i><span class="permanent-link" data-testid="record-detail-title-permanent-link"><span class="middle-ellipsis mr-5">{{ record_permalink | trim }}</span><ClipboardCopyButton className="large" copyText={{record_permalink}} />
     </div>
     <p class="detail text small ml-0">
         <small>{{ _("Use this link when reporting the dataset in RIV.") }}</small>

--- a/uv.lock
+++ b/uv.lock
@@ -3957,14 +3957,14 @@ wheels = [
 
 [[package]]
 name = "oarepo-glitchtip"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple" }
 dependencies = [
     { name = "sentry-sdk", extra = ["flask"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/00/1314d093dd60fd80c8f43cdcbb027c9b59839b5d5a45494b2c94b886ba90/oarepo_glitchtip-1.1.0.tar.gz", hash = "sha256:e9d3029fd6421dd3667b07b82b2f9c99e5ff6e91c828cb30ebe713a28c32dc02", size = 3965, upload-time = "2025-12-09T07:49:10.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/90/787bde2bf25ca5858c02c005ca02fd9afdb81e24bf7c82bb5b397f7240f0/oarepo_glitchtip-1.1.1.tar.gz", hash = "sha256:e0bbc52368c6f470e799287142cd224b60818d872b940f80a1b305e84d23e88c", size = 4003, upload-time = "2026-01-13T09:44:06.216Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/59/6a9c4aac1035b81c1609b0ce717bbfe216bbea622d2460065e2dbc78277a/oarepo_glitchtip-1.1.0-py3-none-any.whl", hash = "sha256:1fcd4223f06f2dcb6b184be940c62c684f2c10b01df2d64318ad8f1dd90e5056", size = 5045, upload-time = "2025-12-09T07:49:09.143Z" },
+    { url = "https://files.pythonhosted.org/packages/77/2e/4408908927b24cbcb8b16dcbbf7619041dca19507eadf6682306b830da45/oarepo_glitchtip-1.1.1-py3-none-any.whl", hash = "sha256:d80def7596ebc64c27d874025f57a1f27c339acee44647a35f2d4cc8edf117cd", size = 5083, upload-time = "2026-01-13T09:44:05.103Z" },
 ]
 
 [[package]]
@@ -4046,7 +4046,7 @@ wheels = [
 
 [[package]]
 name = "oarepo-runtime"
-version = "2.0.0.dev53"
+version = "2.0.0.dev54"
 source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple" }
 dependencies = [
     { name = "langcodes" },
@@ -4054,9 +4054,9 @@ dependencies = [
     { name = "oarepo-invenio-typing-stubs" },
     { name = "signposting" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/51/86f5adc217c383e3c80c1f37188e6b429cda201b389e65b889ce0d335524/oarepo_runtime-2.0.0.dev53.tar.gz", hash = "sha256:c56dcb4920c9507ce9f9963c933236b6d98f7dba492f0c2dba7fcbcdac9ae346", size = 46542, upload-time = "2026-01-07T13:03:16.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/ab/154f7ec771096b205b5852d6a2742b06039caff074e38c02fa8dfc799be6/oarepo_runtime-2.0.0.dev54.tar.gz", hash = "sha256:49ee92270728537370aefbf9e56c7bc644fffe130908477e94c9de4e176ac51d", size = 47172, upload-time = "2026-01-13T13:12:32.38Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/98/7fa2117ed17c68a8a127be33f8e34bd70f935329421fef94e6427ce47c98/oarepo_runtime-2.0.0.dev53-py3-none-any.whl", hash = "sha256:1da5e81b460425a1675d704d16c471c819dad2e1f765d9fbae5a101d7f5a0d2c", size = 70644, upload-time = "2026-01-07T13:03:15.34Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b6/6f17b5d104d55c071c7438879da09ab5f7f46d3802f705c65ee5be7bf904/oarepo_runtime-2.0.0.dev54-py3-none-any.whl", hash = "sha256:83a97393956b675d5e191ff4faecae669e5a61a899ce5c4a3d707751a04bd901", size = 71305, upload-time = "2026-01-13T13:12:31.006Z" },
 ]
 
 [[package]]
@@ -4073,7 +4073,7 @@ wheels = [
 
 [[package]]
 name = "oarepo-ui"
-version = "6.0.0.dev28"
+version = "6.0.0.dev29"
 source = { registry = "https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple" }
 dependencies = [
     { name = "deepmerge" },
@@ -4085,9 +4085,9 @@ dependencies = [
     { name = "oarepo-theme" },
     { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/b4/208e96e119f3d0030dc9a960b1dec1b7ebe79a09b3d5ca362452585ae508/oarepo_ui-6.0.0.dev28.tar.gz", hash = "sha256:e7ee4d8bd79b6634981d00e68f12703c32b7628537efdf9357687cac40d399a6", size = 193746, upload-time = "2026-01-08T15:34:30.251Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e5/3a15a7621eb36b0b0acfa623c135b6a6861ee1a898b4f4982bd509013ef8/oarepo_ui-6.0.0.dev29.tar.gz", hash = "sha256:60000047979d04916974d6dea39a561a6e7b0655e9ca4b800721e91cdad5fcd9", size = 193882, upload-time = "2026-01-12T12:24:13.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/56/19afa4cbe55ec2459c44acc659bb59575b81604fa180125c5b9a69b48fb5/oarepo_ui-6.0.0.dev28-py3-none-any.whl", hash = "sha256:aca890d159080b47f0c885da236c0eb42a66572734c9333edce179580838ce31", size = 321867, upload-time = "2026-01-08T15:34:28.912Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c0/f0412f719463b6ddf825fdfc0356d5d1ef7473c9be72e344634ac83a8a1f/oarepo_ui-6.0.0.dev29-py3-none-any.whl", hash = "sha256:de48075c5fee2b556622c59789328267491e93644a0cb8cc0345596e1f502505", size = 321937, upload-time = "2026-01-12T12:24:11.411Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Make permalink regular text (prevents anoyance with popping up new tab while trying to select&copy) - common copy style for some, is to double click & Ctrl+C

<img width="1181" height="633" alt="Screenshot 2026-01-15 at 12 40 09" src="https://github.com/user-attachments/assets/9c83c5a5-cbe9-46f4-8436-4171b162f91c" />
