### PR TITLE
fix: don't expose metrics on main flask app

### DIFF
--- a/metrics/ext.py
+++ b/metrics/ext.py
@@ -22,7 +22,7 @@ class PrometheusMetricsExporterExt:
     def init_app(self, app: Flask) -> None:
         """Flask application initialization."""
         self.app = app
-        metrics = PrometheusMetrics.for_app_factory()
+        metrics = PrometheusMetrics.for_app_factory(path=None)
         metrics.init_app(app)
 
         app.extensions["metrics-extension"] = self


### PR DESCRIPTION
This prevents /metrics route to be registered on invenio flask app. WSGI module starts its own metrics sidecar server