### PR TITLE
Add harvesters for archaeology communities

### DIFF
--- a/app_data/harvesters.yaml
+++ b/app_data/harvesters.yaml
@@ -76,3 +76,39 @@
   transformer:
     - 'oai-import{"model":"datasets"}'
     - "id-from-doi"
+
+# Archaeological Information System of the Czech Republic (AIS CR) Zenodo community
+# https://www.zenodo.org/communities/aiscr
+- id: zenodo-aiscr
+  name: "Zenodo AISCR community harvester"
+  base-url: "https://zenodo.org"
+  metadata-prefix: "aiscr"
+  model: datasets
+  loader: zenodo
+  transformer:
+    - "zenodo"
+  setspec: 'communities:aiscr AND resource_type.type:dataset'
+  
+# Czech Academy of Sciences, Institute of Archaeology, Prague (ARU) Zenodo community
+# https://www.zenodo.org/communities/iap-cas
+- id: zenodo-arup
+  name: "Zenodo ARUP community harvester"
+  base-url: "https://zenodo.org"
+  metadata-prefix: "arup"
+  model: datasets
+  loader: zenodo
+  transformer:
+    - "zenodo"
+  setspec: 'communities:iap-cas AND resource_type.type:dataset'
+
+# Czech Academy of Sciences, Institute of Archaeology, Brno (ARUB) Zenodo community
+# https://www.zenodo.org/communities/arub
+- id: zenodo-arub
+  name: "Zenodo ARUB community harvester"
+  base-url: "https://zenodo.org"
+  metadata-prefix: "arub"
+  model: datasets
+  loader: zenodo
+  transformer:
+    - "zenodo"
+  setspec: 'communities:arub AND resource_type.type:dataset'

--- a/app_data/harvesters.yaml
+++ b/app_data/harvesters.yaml
@@ -67,7 +67,7 @@
     - "lindat"
 
 - id: av
-  name: "Academy of sciences repository harvester"
+  name: "Academy of Sciences repository harvester"
   base-url: "https://asep.lib.cas.cz/arl-cav/cs/oai/"
   metadata-prefix: "dataciteoai"
   setspec: OAIDATACITE

--- a/app_data/harvesters.yaml
+++ b/app_data/harvesters.yaml
@@ -80,7 +80,7 @@
 # Archaeological Information System of the Czech Republic (AIS CR) Zenodo community
 # https://www.zenodo.org/communities/aiscr
 - id: zenodo-aiscr
-  name: "Zenodo AISCR community harvester"
+  name: "Zenodo AIS CR community harvester"
   base-url: "https://zenodo.org"
   metadata-prefix: "aiscr"
   model: datasets
@@ -89,19 +89,19 @@
     - "zenodo"
   setspec: 'communities:aiscr AND resource_type.type:dataset'
   
-# Czech Academy of Sciences, Institute of Archaeology, Prague (ARU) Zenodo community
+# Czech Academy of Sciences, Institute of Archaeology, Prague Zenodo community
 # https://www.zenodo.org/communities/iap-cas
-- id: zenodo-arup
-  name: "Zenodo ARUP community harvester"
+- id: zenodo-aru
+  name: "Zenodo ARU community harvester"
   base-url: "https://zenodo.org"
-  metadata-prefix: "arup"
+  metadata-prefix: "aru"
   model: datasets
   loader: zenodo
   transformer:
     - "zenodo"
   setspec: 'communities:iap-cas AND resource_type.type:dataset'
 
-# Czech Academy of Sciences, Institute of Archaeology, Brno (ARUB) Zenodo community
+# Czech Academy of Sciences, Institute of Archaeology, Brno Zenodo community
 # https://www.zenodo.org/communities/arub
 - id: zenodo-arub
   name: "Zenodo ARUB community harvester"


### PR DESCRIPTION
PR adds following harvesters:

- Archaeological Information System of the Czech Republic (AIS CR) Zenodo community
- Czech Academy of Sciences, Institute of Archaeology, Prague (ARU) Zenodo community
- Czech Academy of Sciences, Institute of Archaeology, Brno (ARUB) Zenodo community

We prefer to harvest our dedicated "communities", as these are curated by AIS CR and ARU/ARUB staff.